### PR TITLE
fix: command input type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,18 @@ export function apply(ctx: Context, config: Config) {
     return next()
   })
 
-  ctx.command('chatgpt')
+  ctx.command('chatgpt <input:text>')
     .option('reset', '-r')
     .action(async ({ options, session }, input) => {
       if (options?.reset) {
         conversations.delete(session.uid)
         return session.text('.reset-success')
+      }
+
+      input = input.trim()
+      if (!input) {
+        await session.send(session.text('.expect-prompt'))
+        input = await session.prompt()
       }
 
       try {

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -6,6 +6,7 @@ commands:
       reset: 重置对话
 
     messages:
+      expect-prompt: 您想对我说什么呢？
       invalid-token: 会话令牌无效，请联系管理员。
       unknown-error: 发生未知错误。
       reset-success: 已重置对话。


### PR DESCRIPTION
This PR fixes the positional parameter type as text, so if the user enters sentences with spaces, the parts after the space would not be stripped.

Also add a convenient way to handle empty input error.