### PR TITLE
fix: extra endpoint arguments cause ENOTFOUND

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -17,13 +17,11 @@ export interface Conversation {
 
 class ChatGPT {
   protected http: Quester
-  protected _endpoint: string
   // stores access tokens for up to 10 seconds before needing to refresh
   protected _accessTokenCache = new ExpiryMap<string, string>(10 * 1000)
 
   constructor(ctx: Context, public config: ChatGPT.Config) {
     this.http = ctx.http.extend(config)
-    this._endpoint = trimSlash(config.endpoint)
   }
 
   async getIsAuthenticated() {
@@ -68,11 +66,9 @@ class ChatGPT {
       parent_message_id: messageId,
     }
 
-    const url = this._endpoint + '/backend-api/conversation'
-
     let data: internal.Readable
     try {
-      const resp = await this.http.axios<internal.Readable>(url, {
+      const resp = await this.http.axios<internal.Readable>('/backend-api/conversation', {
         method: 'POST',
         responseType: 'stream',
         data: body,
@@ -148,7 +144,7 @@ class ChatGPT {
     }
 
     try {
-      const res = await this.http.get(this._endpoint + '/api/auth/session', {
+      const res = await this.http.get('/api/auth/session', {
         headers: {
           cookie: `__Secure-next-auth.session-token=${this.config.sessionToken}`,
         },


### PR DESCRIPTION
https://github.com/koishijs/chatgpt-bot/blob/38354f1adfc1d556368b2d05c894683ed4e0b95b/src/api.ts#L24-L27

`L25` 这里已经通过 `config` 将 `endpoint` 传进去了

https://github.com/satorijs/satori/blob/1a7cddfade8aecd13707bd8b1ec2f907ba6d6f67/packages/axios/src/index.ts#L154

`cordis-axios` 这里也使用了 `L25` 传入的 `endpoint` 

https://github.com/koishijs/chatgpt-bot/blob/38354f1adfc1d556368b2d05c894683ed4e0b95b/src/api.ts#L71
https://github.com/koishijs/chatgpt-bot/blob/38354f1adfc1d556368b2d05c894683ed4e0b95b/src/api.ts#L151

这里的`this._endpoint + `是完全多余的，导致host被识别成了 `chat.openai.comhttps`