### PR TITLE
支持手动设置accessToken、api点、初始词、模型、超时

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -108,7 +108,7 @@ class ChatGPT {
       let messageId: string
       let conversationId: string
       const parser = createParser((event) => {
-        if (event.type === 'event') {
+        if (event.type === 'event' && event.event !== 'ping') {
           const { data } = event
           if (data === '[DONE]') {
             return resolve({ message: response, messageId, conversationId })

--- a/src/api.ts
+++ b/src/api.ts
@@ -190,6 +190,7 @@ namespace ChatGPT {
     proxyAgent?: string
     model: string
     initialPrompt?: string
+    timeout?: number
   }
 
   export const Config: Schema<Config> = Schema.object({
@@ -206,6 +207,7 @@ namespace ChatGPT {
     }),
     proxyAgent: Schema.string().role('link').description('使用的代理服务器地址。'),
     markdown: Schema.boolean().hidden().default(false),
+    timeout: Schema.number().description('访问超时。').default(60000),
   }).description('登录设置')
 }
 


### PR DESCRIPTION
- feat: Support setting API endpoint and accessToken
- feat: Support setting initialPrompt and model
- feat: Support setting timeout
- fix: event has ping

模型：有plus服务的话可以用plus的加速版
手动设置accessToken等这些是是因为提供bypass服务的反代，api前缀不一定是和官方默认的一样